### PR TITLE
Move App out of site

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,6 +1,6 @@
 <div>
   <div class="header">
-    <h1>EyeOnWater: Australia - WFS Viewer</h1>
+    <h1><a href="https://research.csiro.au/eyeonwater/">EyeOnWater: Australia</a> - WFS Viewer</h1>
 
     <div class="sub-header box-shadow">
       <div class="sub-header-stats"></div>


### PR DESCRIPTION
* Originally it embedded in an IFrame within the Wordpress site
* Changed to be a link out to the site (Wordpress 'menu' updated)
* And the app links back to the site