### PR TITLE
Sync calcs after new data points retrieved

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3213,6 +3213,52 @@
         "semver-intersect": "1.4.0"
       }
     },
+    "@sinonjs/commons": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+      "integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+      "dev": true,
+      "requires": {
+        "type-detect": "4.0.8"
+      }
+    },
+    "@sinonjs/fake-timers": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/@sinonjs/fake-timers/-/fake-timers-6.0.0.tgz",
+      "integrity": "sha512-atR1J/jRXvQAb47gfzSK8zavXy7BcpnYq21ALon0U99etu99vsir0trzIO3wpeLtW+LLVY6X7EkfVTbjGSH8Ww==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "@sinonjs/formatio": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-5.0.1.tgz",
+      "integrity": "sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1",
+        "@sinonjs/samsam": "^5.0.2"
+      }
+    },
+    "@sinonjs/samsam": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-5.0.2.tgz",
+      "integrity": "sha512-p3yrEVB5F/1wI+835n+X8llOGRgV8+jw5BHQ/cJoLBUXXZ5U8Tr5ApwPc4L4av/vjla48kVPoN0t6dykQm+Rvg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.6.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "lodash.get": "^4.4.2",
+        "type-detect": "^4.0.8"
+      }
+    },
+    "@sinonjs/text-encoding": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+      "integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+      "dev": true
+    },
     "@turf/bbox": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-6.0.1.tgz",
@@ -8953,6 +8999,12 @@
         "set-immediate-shim": "~1.0.1"
       }
     },
+    "just-extend": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+      "integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+      "dev": true
+    },
     "karma": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/karma/-/karma-4.1.0.tgz",
@@ -9868,6 +9920,12 @@
       "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
       "dev": true
     },
+    "lodash.get": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
+      "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=",
+      "dev": true
+    },
     "lodash.sortby": {
       "version": "4.7.0",
       "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
@@ -10590,6 +10648,37 @@
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
       "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
       "dev": true
+    },
+    "nise": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/nise/-/nise-4.0.2.tgz",
+      "integrity": "sha512-ALDnm0pTTyeGdbg5FCpWGd58Nmp3qO8d8x+dU2Fw8lApeJTEBSjkBZZM4S8t6GpKh+czxkfM/TKxpRMroZzwOg==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.1",
+        "@sinonjs/text-encoding": "^0.7.1",
+        "just-extend": "^4.0.2",
+        "path-to-regexp": "^1.7.0"
+      },
+      "dependencies": {
+        "isarray": {
+          "version": "0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+          "dev": true
+        },
+        "path-to-regexp": {
+          "version": "1.8.0",
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+          "integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+          "dev": true,
+          "requires": {
+            "isarray": "0.0.1"
+          }
+        }
+      }
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -12821,6 +12910,44 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
       "dev": true
+    },
+    "sinon": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-9.0.0.tgz",
+      "integrity": "sha512-c4bREcvuK5VuEGyMW/Oim9I3Rq49Vzb0aMdxouFaA44QCFpilc5LJOugrX+mkrvikbqCimxuK+4cnHVNnLR41g==",
+      "dev": true,
+      "requires": {
+        "@sinonjs/commons": "^1.7.0",
+        "@sinonjs/fake-timers": "^6.0.0",
+        "@sinonjs/formatio": "^5.0.0",
+        "@sinonjs/samsam": "^5.0.1",
+        "diff": "^4.0.2",
+        "nise": "^4.0.1",
+        "supports-color": "^7.1.0"
+      },
+      "dependencies": {
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
+        }
+      }
     },
     "skmeans": {
       "version": "0.9.7",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "karma-jasmine-html-reporter": "^1.4.0",
     "mocha": "^6.2.2",
     "protractor": "~5.4.0",
+    "sinon": "^9.0.0",
     "ts-node": "~7.0.0",
     "tslint": "~5.15.0",
     "typescript": "~3.5.3"

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -261,9 +261,11 @@ export class AppComponent implements OnInit {
    * DEBUG - find centroids for ALL water bodies and plot something - eg. my avatar
    */
   private async calculateWaterBodiesCentroidsPlot() {
-    const layerName = 'i5516 reservoirs';
-    const eowWaterbodyPoints: EowWaterBodyIntersection[] = await GeometryOps.convertLayerToDataFormat(this.layersGeometries, layerName);
-    this.eowDataCharts.plotCharts(eowWaterbodyPoints, layerName);
+    const layerName = 'DigitalEarthAustraliaWaterbodies';
+    if (this.waterBodyFeatures.hasOwnProperty(layerName)) {
+      const eowWaterbodyPoints: EowWaterBodyIntersection[] = await GeometryOps.convertLayerToDataFormat(this.waterBodyFeatures[layerName]);
+      this.eowDataCharts.plotCharts(eowWaterbodyPoints, layerName);
+    }
   }
 
   private debug_printFirstEOWData() {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -292,7 +292,8 @@ export class AppComponent implements OnInit {
     if (this.ready()) {
       const theFeatures = givenWaterBodyFeatures ? givenWaterBodyFeatures : this.waterBodyFeatures;   // choose argument or global data
       // Maybe debug, maybe not.  Don't perform calculations when zoomed out too far
-      console.warn(`Resolution: ${this.map.getView().getResolution()}`);
+      const date = new Date();
+      console.warn(`Resolution: ${this.map.getView().getResolution()} - ${date.getSeconds()}:${date.getMilliseconds()}`);
       if (this.map.getView().getZoom() >= 9) {
         this.log.verbose(theClass, `  *** -> calculateIntersectionsPlot loop -`);
         this.log.verbose(theClass, `    points#: ${this.points.features.length}, allPointsMap#: ${Object.keys(this.allPointsMap).length}, `

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -149,7 +149,7 @@ export class AppComponent implements OnInit {
       this.eowDataGeometries.getPointsErrorMargin(),
     ]);
     uberObserver.subscribe(async (value) => {
-      console.log(`uberObserver - value length: ${value.filter(v => v !== null).length}`);
+      this.log.verbose(theClass, `uberObserver - value length: ${value.filter(v => v !== null).length}`);
       const [points, allPoints, allPointsMap, errorMarginPoints] = value;
       if (points && allPoints && allPointsMap && errorMarginPoints) {
         handlePointsObserver(points);
@@ -162,18 +162,6 @@ export class AppComponent implements OnInit {
           await this.calculateIntersectionsPlot();
         }
       }
-    });
-    this.eowDataGeometries.getPoints().subscribe(value => {
-      console.log(`eowDataGeometries.getPoints value emitted`);
-    });
-    this.eowDataGeometries.getAllPoints().subscribe(value => {
-      console.log(`eowDataGeometries.getAllPoints value emitted`);
-    });
-    this.eowDataGeometries.getAllPointsMap().subscribe(value => {
-      console.log(`eowDataGeometries.getAllPointsMap value emitted`);
-    });
-    this.eowDataGeometries.getPointsErrorMargin().subscribe(value => {
-      console.log(`eowDataGeometries.getPointsErrorMargin value emitted`);
     });
     this.eowLayers.waterBodiesLayers.getLayersInfo().subscribe(layersInfo => {
       // I want to subscribe to layer's VectorSource observer and when triggers call calculateIntersectionsPlot()
@@ -206,24 +194,24 @@ export class AppComponent implements OnInit {
       this.points = points;
       this.newPoints = true;
       const pointsLength = this.points ? this.points.features.length : 'null';
-      console.log(`  pointsObs subscription updated - points#: ${pointsLength}`);
+      this.log.verbose(theClass, `  pointsObs subscription updated - points#: ${pointsLength}`);
     };
 
     const handleAllPointsObserver = (allPoints: FeatureCollection<Point>) => {
       this.sourceNErrorMarginPoints = allPoints;
       const theSourceNErrorMarginPointsLength = this.sourceNErrorMarginPoints ? this.sourceNErrorMarginPoints.features.length : 'null';
-      console.log(`  sourceNErrorMarginPoints subscription updated - points#: ${theSourceNErrorMarginPointsLength}`);
+      this.log.verbose(theClass, `  sourceNErrorMarginPoints subscription updated - points#: ${theSourceNErrorMarginPointsLength}`);
     };
 
     const handlePointsMapObserver = (allPointsMap: PointsMap) => {
       this.allPointsMap = allPointsMap;
       const theAllPointsMapObsLength = this.allPointsMap ? Object.keys(this.allPointsMap).length : 'null';
-      console.log(`  allPointsMap subscription updated - points#: ${theAllPointsMapObsLength}`);
+      this.log.verbose(theClass, `  allPointsMap subscription updated - points#: ${theAllPointsMapObsLength}`);
     };
 
     const handleErrorMarginPoints = (pointsErrorMargins: SourcePointMarginsType[]) => {
       this.pointsErrorMargins = pointsErrorMargins;
-      console.log(`  pointsErrorMargins subscription updated - points#: ${pointsErrorMargins.length}`);
+      this.log.verbose(theClass, `  pointsErrorMargins subscription updated - points#: ${pointsErrorMargins.length}`);
     };
 
   }
@@ -247,8 +235,8 @@ export class AppComponent implements OnInit {
   }
 
   private async performRunWhenNewData() {
-    console.log(`  *** -> performRunWhenNewData -`);
-    console.log(`    totalNumberWaterBodyFeatures: ${this.totalNumberWaterBodyFeatures}, points#: ${this.points && this.points.features.length},`
+    this.log.verbose(theClass, `  *** -> performRunWhenNewData -`);
+    this.log.verbose(theClass, `    totalNumberWaterBodyFeatures: ${this.totalNumberWaterBodyFeatures}, points#: ${this.points && this.points.features.length},`
       + `allPointsMap#: ${this.allPointsMap && Object.keys(this.allPointsMap).length}, `
       + `sourceNErrorMarginPoints#: ${this.sourceNErrorMarginPoints && this.sourceNErrorMarginPoints.features.length}, `
       + `waterBodyLayers#: ${this.waterBodiesLayers && this.waterBodiesLayers.length}, newPoints: ${this.newPoints}, newWaterbodiesData: ${this.newWaterbodiesData}`);
@@ -300,19 +288,19 @@ export class AppComponent implements OnInit {
    * means that no layer data has changed and to just apply the EOWData Points to all layers in this.waterBodyFeatures
    */
   async calculateIntersectionsPlot(givenWaterBodyFeatures: WaterBodyFeatures = null) {
-    console.log(`calculateIntersectionsPlot called`);
+    this.log.verbose(theClass, `calculateIntersectionsPlot called`);
     if (this.ready()) {
       const theFeatures = givenWaterBodyFeatures ? givenWaterBodyFeatures : this.waterBodyFeatures;   // choose argument or global data
       // Maybe debug, maybe not.  Don't perform calculations when zoomed out too far
       console.warn(`Resolution: ${this.map.getView().getResolution()}`);
       if (this.map.getView().getZoom() >= 9) {
-        console.log(`  *** -> calculateIntersectionsPlot loop -`);
-        console.log(`    points#: ${this.points.features.length}, allPointsMap#: ${Object.keys(this.allPointsMap).length}, `
+        this.log.verbose(theClass, `  *** -> calculateIntersectionsPlot loop -`);
+        this.log.verbose(theClass, `    points#: ${this.points.features.length}, allPointsMap#: ${Object.keys(this.allPointsMap).length}, `
           + `sourceNErrorMarginPoints#: ${this.sourceNErrorMarginPoints.features.length}, waterBodyLayers#: ${this.waterBodiesLayers.length}`);
         for (const waterBodyLayerName of Object.keys(theFeatures)) {
           // Get the features in the view
           const waterBodyFeatures: Feature[] = theFeatures[waterBodyLayerName];
-          console.log(`     waterBodyLayer loop for: ${waterBodyLayerName} - Features in View#: ${waterBodyFeatures.length}`);
+          this.log.verbose(theClass, `     waterBodyLayer loop for: ${waterBodyLayerName} - Features in View#: ${waterBodyFeatures.length}`);
           // Convert to polygons
           const waterBodyFeatureCollection: FeatureCollection<Polygon> = this.layersGeometries.createFeatureCollection(waterBodyFeatures);
 
@@ -322,8 +310,6 @@ export class AppComponent implements OnInit {
       } else {
         console.warn(`Not performating calculations or drawing charts - zoomed too far out: ${this.map.getView().getZoom()}`);
       }
-    } else {
-      console.log(`Data not ready`);
     }
   }
 
@@ -355,7 +341,7 @@ export class AppComponent implements OnInit {
     if (this.allDataSource) {
       const features = this.allDataSource.getFeatures();
       const point = features.length > 0 ? (features[0].getGeometry() as SimpleGeometry).getFirstCoordinate() : 'no data yet';
-      console.log(`First EOWData point: ${point}`);
+      this.log.verbose(theClass, `First EOWData point: ${point}`);
     }
   }
 
@@ -363,22 +349,22 @@ export class AppComponent implements OnInit {
     return; // don't want it currently
     // Delay so other allDataSource.on('change' that loads the data gets a chance to fire
     if (this.allDataSource) {
-      console.log('debug_compareUsersNMeasurements:');
+      this.log.verbose(theClass, 'debug_compareUsersNMeasurements:');
       Object.keys(this.userStore.userById).forEach(uid => {
         const user = this.userStore.userById[uid];
-        console.log(`  user - Id: ${user.id}, nickName: ${user.nickname}, photo_count: ${user.photo_count}`);
+        this.log.verbose(theClass, `  user - Id: ${user.id}, nickName: ${user.nickname}, photo_count: ${user.photo_count}`);
         const m = this.measurementStore.getByOwner(user.id);
         if (m && m.length > 0) {
           const images = m.map(m2 => m2.get('image'));
-          console.log(`    number of images: ${images.length} -> \n${JSON.stringify(images, null, 2)}`);
+          this.log.verbose(theClass, `    number of images: ${images.length} -> \n${JSON.stringify(images, null, 2)}`);
         }
       });
       // Now print Measurements info
-      console.log(`measurementsByOwner: ${
+      this.log.verbose(theClass, `measurementsByOwner: ${
         JSON.stringify(this.measurementStore.measurementSummary(true, this.userStore), null, 2)}`);
-      console.log(`measurementsById: ${
+      this.log.verbose(theClass, `measurementsById: ${
         JSON.stringify(this.measurementStore.measurementSummary(false, this.userStore), null, 2)}`);
-      console.log(`Number of measurements per user: ${
+      this.log.verbose(theClass, `Number of measurements per user: ${
         JSON.stringify(this.measurementStore.numberMeasurmentsPerUser(this.userStore), null, 2)}`);
     }
   }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -2,8 +2,9 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 import { AppComponent } from './app.component';
-import {HttpClient, HttpClientModule} from '@angular/common/http';
+import {HttpClientModule} from '@angular/common/http';
 import {Brolog} from 'brolog';
+import {brologLevel} from './globals';
 
 @NgModule({
   declarations: [
@@ -16,9 +17,9 @@ import {Brolog} from 'brolog';
     {
       provide: Brolog,
       // 'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'silly'
-      useFactory: function brologFactory() { return Brolog.instance('warn'); }
+      useFactory: function brologFactory() { return Brolog.instance(brologLevel); }
     }
   ],
   bootstrap: [AppComponent]
 })
-export class AppModule { }
+export class AppModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,7 +16,7 @@ import {Brolog} from 'brolog';
     {
       provide: Brolog,
       // 'silent' | 'error' | 'warn' | 'info' | 'verbose' | 'silly'
-      useFactory: function brologFactory() { return Brolog.instance('verbose'); }
+      useFactory: function brologFactory() { return Brolog.instance('warn'); }
     }
   ],
   bootstrap: [AppComponent]

--- a/src/app/charts/eow-data-charts.ts
+++ b/src/app/charts/eow-data-charts.ts
@@ -29,7 +29,7 @@ export default class EowDataCharts {
   htmlDocument: Document;
   ids: { [id: string]: boolean } = {};
 
-  constructor(private geometryOps: GeometryOps, private layers: Layers, private log: Brolog) {
+  constructor(private layers: Layers, private log: Brolog) {
   }
 
   init(eowMap: EOWMap, htmlDocument) {
@@ -74,7 +74,7 @@ export default class EowDataCharts {
         let centroid;
         if (points.length > 1) {
           this.log.silly(theClass + '.plot', `EOWDatum points: ${JSON.stringify(points)}`);
-          centroid = this.geometryOps.calculateCentroidFromPoints(points).geometry.coordinates;
+          centroid = GeometryOps.calculateCentroidFromPoints(points).geometry.coordinates;
         } else if (points.length === 1) {
           centroid = points[0];
         }

--- a/src/app/charts/pie-chart.ts
+++ b/src/app/charts/pie-chart.ts
@@ -2,32 +2,19 @@ import colors from '../colors.json';
 import {
   Brolog,
 } from 'brolog';
-// import * as d3 from 'd3';
-import { select } from 'd3-selection';
-import { scaleLinear } from 'd3-scale';
-import { extent } from 'd3-array';
-import { pie, arc } from 'd3-shape';
-import {PieItem, PieItemObject, PieItems} from '../eow-data-struct';
+import {select} from 'd3-selection';
+import {pie, arc} from 'd3-shape';
+import {PieItem, PieItems} from '../eow-data-struct';
+import {brologLevel} from '../globals';
 
+const log = Brolog.instance(brologLevel);  // InjectorInstance.get<Brolog>(Brolog);
 const theClass = 'PieChart';
 
 const widthFactor = 9;
 const pieWidth = 1.0;
 const opaqueness = 0.7;
 
-const brologLevel = 'verbose';
-const log = new Brolog();
-
-const STATIC_INIT = Symbol();
-
 export class PieChart {
-  /**
-   * Static Constructor (called at end of file)
-   */
-  public static[STATIC_INIT] = () => {
-    log.level(brologLevel);
-  }
-
   /**
    * Draw pie chart of features (FU Values) at elementId
    *
@@ -65,13 +52,13 @@ export class PieChart {
     // 3. Draw canvas
 
     const wrapper = select('#' + elementId)
-    // .attr('class', 'svg-container')
+      // .attr('class', 'svg-container')
       .append('svg')
       .attr('width', '' + dimensions.width)
       .attr('height', '' + dimensions.height);
 
     const bounds = wrapper.append('g');
-      // .style('transform', `translate(${dimensions.margin.left}px, ${dimensions.margin.top}px)`);
+    // .style('transform', `translate(${dimensions.margin.left}px, ${dimensions.margin.top}px)`);
 
     // 4. Create scales
 
@@ -158,6 +145,3 @@ export class PieChart {
     return html.replace('class="pieChart"', 'id="pieChart"');
   }
 }
-
-// Call the init once
-PieChart[STATIC_INIT]();

--- a/src/app/charts/time-series-chart.ts
+++ b/src/app/charts/time-series-chart.ts
@@ -1,13 +1,14 @@
 import {
   Brolog,
 } from 'brolog';
-// import d3 from 'd3';
 import { select } from 'd3-selection';
 import { scaleTime } from 'd3-scale';
 import { extent } from 'd3-array';
 import colors from '../colors.json';
-import {PieChart} from './pie-chart';
 import {TimeSeriesItem, TimeSeriesItems} from '../eow-data-struct';
+import {brologLevel} from '../globals';
+
+const log = Brolog.instance(brologLevel);  // InjectorInstance.get<Brolog>(Brolog);
 
 const theClass = 'TimeSeriesChart';
 
@@ -15,20 +16,7 @@ const widthFactor = 10;
 const pieWidth = 1.0;
 const opaqueness = 0.7;
 
-// TODO - need to use common application level
-const brologLevel = 'verbose';
-const log = new Brolog();
-
-const STATIC_INIT = Symbol();
-
 export class TimeSeriesChart {
-  /**
-   * Static Constructor (called at end of file)
-   */
-  public static [STATIC_INIT] = () => {
-    log.level(brologLevel);
-  }
-
   /**
    * Draw pie chart of features (FU Values) at elementId
    *
@@ -117,6 +105,3 @@ export class TimeSeriesChart {
   }
 
 }
-
-// Call the init once
-TimeSeriesChart[STATIC_INIT]();

--- a/src/app/eow-data-geometries.ts
+++ b/src/app/eow-data-geometries.ts
@@ -92,7 +92,7 @@ export default class EowDataGeometries {
   }
 
   /**
-   * Read the EOW Data points from the WFS end point.  Saves in the
+   * Read the EOW Data points when the dataSource changes due to BBOXStrategy on the map
    *
    * This calculates the data and saves in pointsObs Behaviour Subject (an Observable).
    */

--- a/src/app/eow-data-geometries.ts
+++ b/src/app/eow-data-geometries.ts
@@ -109,7 +109,7 @@ export default class EowDataGeometries {
       const points = turfFeatureCollection(features);
       if (points.features.length !== this.pointsNumber) {
         this.points = points;
-        console.log(`update pointsObs - items#: ${this.points.features.length}`);
+        this.log.verbose(theClass, `update pointsObs - items#: ${this.points.features.length}`);
         this.pointsNumber = this.points.features.length;
         this._pointsObs.next(this.points);
       }
@@ -150,14 +150,14 @@ export default class EowDataGeometries {
 
       if (errorMarginPoints.length !== this.pointsErrorMarginNumber) {
         this.pointsErrorMargin = errorMarginPoints;
-        console.log(`update pointsErrorMarginObs - items#: ${errorMarginPoints.length}`);
+        this.log.verbose(theClass, `update pointsErrorMarginObs - items#: ${errorMarginPoints.length}`);
         this.pointsErrorMarginNumber = errorMarginPoints.length;
         this._pointsErrorMarginObs.next(errorMarginPoints);
       }
 
       if (allPoints.features.length !== this.allPointsNumber) {
         this.allPoints = allPoints;
-        console.log(`update allPointsObs - items#: ${allPoints.features.length}`);
+        this.log.verbose(theClass, `update allPointsObs - items#: ${allPoints.features.length}`);
         this.allPointsNumber = allPoints.features.length;
         this._allPointsObs.next(allPoints);
       }
@@ -185,7 +185,7 @@ export default class EowDataGeometries {
       });
 
       if (Object.keys(pointsMap).length !== this.pointsErrorMarginNumber) {
-        console.log(`update allPointsMapObs - items#: ${Object.keys(pointsMap).length}`);
+        this.log.verbose(theClass, `update allPointsMapObs - items#: ${Object.keys(pointsMap).length}`);
         this.pointsErrorMarginNumber = Object.keys(pointsMap).length;
         this._allPointsMapObs.next(pointsMap);
       }

--- a/src/app/eow-data-geometries.ts
+++ b/src/app/eow-data-geometries.ts
@@ -10,13 +10,14 @@ import {
   Brolog,
 } from 'brolog';
 import SimpleGeometry from 'ol/geom/SimpleGeometry';
-import {BehaviorSubject} from 'rxjs';
+import {BehaviorSubject, interval} from 'rxjs';
 import {featureEach} from '@turf/meta';
 import circle from '@turf/circle';
 import {EowDataStruct, PointsMap, SourcePointMarginsType} from './eow-data-struct';
 import {LayersInfo} from './eow-layers';
 import {EowDataLayer} from './eow-data-layer';
 import VectorSource from 'ol/source/Vector';
+import {debounce} from 'rxjs/operators';
 
 const theClass = 'EowDataGeometries';
 
@@ -76,19 +77,19 @@ export default class EowDataGeometries {
   }
 
   public getPoints() {
-    return this._pointsObs.asObservable();
+    return this._pointsObs.asObservable().pipe(debounce(() => interval(1000)));
   }
 
   public getPointsErrorMargin() {
-    return this._pointsErrorMarginObs.asObservable();
+    return this._pointsErrorMarginObs.asObservable().pipe(debounce(() => interval(1000)));
   }
 
   public getAllPointsMap() {
-    return this._allPointsMapObs.asObservable();
+    return this._allPointsMapObs.asObservable().pipe(debounce(() => interval(1000)));
   }
 
   public getAllPoints() {
-    return this._allPointsObs.asObservable();
+    return this._allPointsObs.asObservable().pipe(debounce(() => interval(1000)));
   }
 
   /**

--- a/src/app/eow-data-struct.ts
+++ b/src/app/eow-data-struct.ts
@@ -1,27 +1,32 @@
 import Brolog from 'brolog';
-import {Feature, feature as turfFeature, FeatureCollection, Point, point as turfPoint, Polygon} from '@turf/helpers';
+import {Feature, FeatureCollection, Point, point as turfPoint, Polygon} from '@turf/helpers';
 import {Position} from 'geojson';
 import moment from 'moment';
+import {brologLevel} from './globals';
 
 const theClass = 'EowDataStruct';
-const brologLevel = 'verbose';
-const log = new Brolog();
+const log = Brolog.instance(brologLevel);  // InjectorInstance.get<Brolog>(Brolog);
 
 export type Coords = [number, number];
+
 export interface TimeSeriesItem {
   fu: string;
   date: string;
   index: number;
 }
+
 export type TimeSeriesItems = TimeSeriesItem[];
+
 export interface PieItemObject {
   count: number;
   points: Coords[];
 }
+
 export interface PieItem {
   name: string;
   y: PieItemObject;
 }
+
 export type PieItems = PieItem[];
 
 /**
@@ -50,16 +55,7 @@ export interface SourcePointMarginsType {
 
 export type PointsMap = { [pointString: string]: Feature<Point> };  // tslint:disable-line
 
-const STATIC_INIT = Symbol();
-
 export class EowDataStruct {
-  /**
-   * Static Constructor (called at end of file)
-   */
-  public static[STATIC_INIT] = () => {
-    log.level(brologLevel);
-  }
-
   /**
    * @Return Aggregated FU data as an array of objects:
    * [
@@ -223,6 +219,3 @@ export class EowDataStruct {
     return [precise(p[0]), precise(p[1])];
   }
 }
-
-// Call the init once
-EowDataStruct[STATIC_INIT]();

--- a/src/app/eow-layers.ts
+++ b/src/app/eow-layers.ts
@@ -39,6 +39,11 @@ export interface LayersSourceSetup {
    */
   tiled?: boolean;
   /**
+   * Query string to pass in with requests.  It is appended to the GET request with `cql_filter=<the query> AND BBOX(geom, <extent>, 'EPSG:4326')`.
+   * This query is used to filter at the server eg. `area>100000` (meters square)
+   */
+  query?: string;
+  /**
    * Zoom and resolution.  The resolution values are more accurate but if not given the zoom ones (coarser) will be used
    */
   minZoom?: number;
@@ -119,7 +124,7 @@ export class EowLayers {
     this.setupWFSLayer(layerPromises, 'http://hotspots.dea.ga.gov.au/geoserver/public/wfs',
       {
         createLayer: true, useAsWaterBodySource: true, layerOrFeatureName: 'DigitalEarthAustraliaWaterbodies', featurePrefix: 'public',
-        layerDisplayName: 'DEA Waterbodies Features', maxResolution: 0.00069
+        layerDisplayName: 'DEA Waterbodies Features', maxResolution: 0.00069, query: 'area>100000'
       });
 
     this.setupWMSLayer(layerPromises, 'http://hotspots.dea.ga.gov.au/geoserver/public/wms',

--- a/src/app/eow-layers.ts
+++ b/src/app/eow-layers.ts
@@ -1,6 +1,7 @@
 import {Brolog} from 'brolog';
 import {Layers} from './layers';
 import {BehaviorSubject} from 'rxjs';
+import VectorSource from 'ol/source/Vector';
 
 const theClass = 'Layers';
 
@@ -52,28 +53,41 @@ export interface LayersInfo {
   index: number;        // of the layer in the map's layers array
   url: string;
   options: LayersSourceSetup;
+  observable: BehaviorSubject<VectorSource>;  // so can watch for changes in the data that happens due to BBoxStrategy
 }
 
 /**
  * Class for the management of the LayersInfo.  Only WFS that define Waterbodies will be stored.
  */
-export class LayersInfoMangar {
+export class LayersInfoManager {
   private _layersInfo = new BehaviorSubject<LayersInfo[]>([]);
   private layersInfo: LayersInfo[] = [];
 
-  public addInfo(name, index, url, options) {
-    this.layersInfo.push({name, index, url, options});
+  public addInfo(name, index, url, options, observable?) {
+    this.layersInfo.push({name, index, url, options, observable});
     // subscribers will get the lot each time the subscription updates.  Using Object.assign to send a copy.
     this._layersInfo.next(Object.assign([], this.layersInfo));
   }
 
+  /**
+   * @Return observable of the layers information to subscribe to
+   */
   public getLayersInfo() {
     return this._layersInfo.asObservable();
+  }
+
+  /**
+   * @param layerName to lookup
+   * @return the layersInfo for the layer with the given name or null if it doesnt exist
+   */
+  public getLayerInfo(layerName: string): LayersInfo {
+    const layerInfo = this.layersInfo.filter(l => l.name === layerName);
+    return layerInfo.length > 0 ? layerInfo[0] : null;
   }
 }
 
 export class EowLayers {
-  waterBodiesLayers = new LayersInfoMangar();
+  waterBodiesLayers = new LayersInfoManager();
 
   constructor(private layers: Layers, private log: Brolog) {
   }
@@ -103,16 +117,22 @@ export class EowLayers {
     this.setupGeoJSONLayer(layerPromises, 'assets/waterbodies/Canberra/i5516_reservoirs.geojson',
       {createLayer: false, useAsWaterBodySource: false, layerDisplayName: 'i5516 reservoirs'});
     this.setupWFSLayer(layerPromises, 'http://hotspots.dea.ga.gov.au/geoserver/public/wfs',
-      {createLayer: true, useAsWaterBodySource: true, layerOrFeatureName: 'DigitalEarthAustraliaWaterbodies', featurePrefix: 'public',
-        layerDisplayName: 'DEA Waterbodies Features', maxResolution: 0.00069});
+      {
+        createLayer: true, useAsWaterBodySource: true, layerOrFeatureName: 'DigitalEarthAustraliaWaterbodies', featurePrefix: 'public',
+        layerDisplayName: 'DEA Waterbodies Features', maxResolution: 0.00069
+      });
 
-    this.setupWMSLayer(layerPromises,  'http://hotspots.dea.ga.gov.au/geoserver/public/wms',
-      {createLayer: true, useAsWaterBodySource: false, layerOrFeatureName: 'DigitalEarthAustraliaWaterbodies',
-        layerDisplayName: 'DEA Waterbodies Map', minResolution: 0.00069, tiled: true});
+    this.setupWMSLayer(layerPromises, 'http://hotspots.dea.ga.gov.au/geoserver/public/wms',
+      {
+        createLayer: true, useAsWaterBodySource: false, layerOrFeatureName: 'DigitalEarthAustraliaWaterbodies',
+        layerDisplayName: 'DEA Waterbodies Map', minResolution: 0.00069, tiled: true
+      });
 
-    this.setupWMSLayer(layerPromises,  'https://ows.dea.ga.gov.au',
-      {createLayer: true, useAsWaterBodySource: false, minResolution: 0.00069, tiled: true,
-        layerOrFeatureName: 'wofs_filtered_summary', layerDisplayName: 'WOFS'});
+    this.setupWMSLayer(layerPromises, 'https://ows.dea.ga.gov.au',
+      {
+        createLayer: true, useAsWaterBodySource: false, minResolution: 0.00069, tiled: true,
+        layerOrFeatureName: 'wofs_filtered_summary', layerDisplayName: 'WOFS'
+      });
 
     // layerPromises.push(this.layers.createLayerFromWFSURL('Digital Earth Australia Waterbodies', 'https://hotspots.dea.ga.gov.au/geoserver/public/wfs'));
 
@@ -124,6 +144,7 @@ export class EowLayers {
       layerPromises.push(this.layers.createLayerFromGeoJSON(url, options, this.waterBodiesLayers));
     }
   }
+
   // private setupWFSLayer(waterBodiesLayers: LayersInfo[], layerPromises: Promise<any>[], name: string, url: string, featurePrefix: string, options: LayersSetup) {
   private setupWFSLayer(layerPromises: Promise<any>[], url: string, options: LayersSourceSetup) {
     if (options.createLayer) {

--- a/src/app/eow-layers.ts
+++ b/src/app/eow-layers.ts
@@ -2,6 +2,8 @@ import {Brolog} from 'brolog';
 import {Layers} from './layers';
 import {BehaviorSubject} from 'rxjs';
 import VectorSource from 'ol/source/Vector';
+import { interval } from 'rxjs';
+import { debounce } from 'rxjs/operators';
 
 const theClass = 'Layers';
 
@@ -78,7 +80,7 @@ export class LayersInfoManager {
    * @Return observable of the layers information to subscribe to
    */
   public getLayersInfo() {
-    return this._layersInfo.asObservable();
+    return this._layersInfo.asObservable().pipe(debounce(() => interval(1000)));
   }
 
   /**
@@ -124,7 +126,7 @@ export class EowLayers {
     this.setupWFSLayer(layerPromises, 'http://hotspots.dea.ga.gov.au/geoserver/public/wfs',
       {
         createLayer: true, useAsWaterBodySource: true, layerOrFeatureName: 'DigitalEarthAustraliaWaterbodies', featurePrefix: 'public',
-        layerDisplayName: 'DEA Waterbodies Features', maxResolution: 0.00069, query: 'area>100000'
+        layerDisplayName: 'DEA Waterbodies Features', maxResolution: 0.05, query: 'area>100000'
       });
 
     this.setupWMSLayer(layerPromises, 'http://hotspots.dea.ga.gov.au/geoserver/public/wms',

--- a/src/app/eow-map.ts
+++ b/src/app/eow-map.ts
@@ -77,10 +77,11 @@ export class EOWMap {
     });
 
     // Draw the EOW Artefacts initially and after the map moves / zooms
-    this.map.on('moveend', async (evt) => {
-      console.log(`map moveend`);
-      await this.app.calculateIntersectionsPlot();
-    });
+    // this.map.on('moveend', async (evt) => {
+    //   console.log(`map moveend`);
+    //   // TODO - with changes in app.component to handle when get new waterbodies data (uses 'moveend'),this may no longer be needed
+    //   await this.app.calculateIntersectionsPlot();
+    // });
   }
 
   /**

--- a/src/app/geometry-ops.ts
+++ b/src/app/geometry-ops.ts
@@ -135,7 +135,7 @@ export default class GeometryOps {
   }
 
   calculateCentroidFromPoints(points: number[][]): Feature<Point> {
-    this.log.verbose('calculateCentroidFromPoints', `  points: ${JSON.stringify(points)}`);
+    this.log.verbose('calculateCentroidFromPoints', `  points length: ${points.length}`);
     return this.calculateCentroidTurfVerUsingPoints(points);
 
     // I'm happy to let my code go and use the library version for now

--- a/src/app/geometry-ops.ts
+++ b/src/app/geometry-ops.ts
@@ -12,13 +12,12 @@ import centroid from '@turf/centroid';
 import pointsWithinPolygon from '@turf/points-within-polygon';
 import {Brolog} from 'brolog';
 import {EowDataStruct, EowWaterBodyIntersection, PointsMap} from './eow-data-struct';
+import {brologLevel} from './globals';
 
 const theClass = 'GeometryOps';
+const log = Brolog.instance(brologLevel);  // InjectorInstance.get<Brolog>(Brolog);
 
 export default class GeometryOps {
-  constructor(private log: Brolog) {
-  }
-
   /**
    * Calculate the intersection between the polygons from layerName and the EOW Data Points
    * @param eowDataGeometry - EOW Data Points object -

--- a/src/app/geometry-ops.ts
+++ b/src/app/geometry-ops.ts
@@ -68,42 +68,42 @@ export default class GeometryOps {
    *          waterBody: null,
    *          eowData: null
    */
-  async calculateLayerIntersections(eowDataGeometry: FeatureCollection<Point>, errorMarginPoints: FeatureCollection<Point>,
-                                    allPointsMap: PointsMap, waterBodyLayerPolygons: FeatureCollection<Polygon>, layerName: string):
+  static async calculateLayerIntersections(eowDataGeometry: FeatureCollection<Point>, errorMarginPoints: FeatureCollection<Point>,
+                                           allPointsMap: PointsMap, waterBodyLayerPolygons: FeatureCollection<Polygon>, layerName: string):
     Promise<EowWaterBodyIntersection[]> {
     return new Promise<EowWaterBodyIntersection[]>(resolve => {
       const layerGeometry: Feature<Polygon>[] = waterBodyLayerPolygons.features;
       const eowWaterBodyIntersections: EowWaterBodyIntersection[] = [];
       const pointsToUse = errorMarginPoints ? errorMarginPoints : eowDataGeometry;
 
-      this.log.info(theClass, `GeometryOps / calculateIntersection for "${layerName}"`);
+      log.info(theClass, `GeometryOps / calculateIntersection for "${layerName}"`);
       const details = layerGeometry.length > 0 ? layerGeometry[0].geometry.coordinates[0][0] : 'no polygons';
-      this.log.verbose(theClass, `layerPolygons - there are: ${layerGeometry.length} - coords of first is: ${details}`);
+      log.verbose(theClass, `layerPolygons - there are: ${layerGeometry.length} - coords of first is: ${details}`);
       for (const layerPolygon of layerGeometry) {
         const intersection: FeatureCollection<Point> = pointsWithinPolygon(pointsToUse, layerPolygon) as FeatureCollection<Point>;
         // TODO - now build a FeatureCollection<Point> from allPointsMapObs
-        const intersectionSourcePoints = this.filterSourcePoints(intersection, allPointsMap);
+        const intersectionSourcePoints = GeometryOps.filterSourcePoints(intersection, allPointsMap);
         eowWaterBodyIntersections.push(EowDataStruct.createEoWFormat(intersectionSourcePoints, layerPolygon));
       }
-      this.log.silly(theClass, `intersections: ${JSON.stringify(eowWaterBodyIntersections, null, 2)}`);
+      log.silly(theClass, `intersections: ${JSON.stringify(eowWaterBodyIntersections, null, 2)}`);
       resolve(eowWaterBodyIntersections);
     });
   }
 
   // Mainly for debug purposes so I can see something happening!  I don't think the EOW Data is intersecting the polygons and want to know more.
-  async convertLayerToDataFormat(layerGeometries: LayerGeometries, layerName: string):
+  static async convertLayerToDataFormat(layerGeometries: LayerGeometries, layerName: string):
     Promise<EowWaterBodyIntersection[]> {
     return new Promise<EowWaterBodyIntersection[]>(resolve => {
       const layerGeometry: Feature<Polygon>[] = layerGeometries.getLayer(layerName);
       const eowWaterBodyPoints: EowWaterBodyIntersection[] = [];
 
-      this.log.verbose(theClass, `GeometryOps / calculateIntersection for "${layerName}"`);
+      log.verbose(theClass, `GeometryOps / calculateIntersection for "${layerName}"`);
       for (const layerPolygon of layerGeometry) {
         const thePoints: Feature<Point>[] = layerPolygon.geometry.coordinates[0].map(c => turfPoint(c));
         const theFeatureCollection = featureCollection(thePoints);
         eowWaterBodyPoints.push(EowDataStruct.createEoWFormat(theFeatureCollection, layerPolygon));
       }
-      this.log.silly(theClass, `convertLayerToDataForamt: ${JSON.stringify(eowWaterBodyPoints, null, 2)}`);
+      log.silly(theClass, `convertLayerToDataForamt: ${JSON.stringify(eowWaterBodyPoints, null, 2)}`);
       resolve(eowWaterBodyPoints);
     });
   }
@@ -114,11 +114,11 @@ export default class GeometryOps {
    *
    * @param featurePoints that makes a polygon to get he centroid for
    */
-  calculateCentroidTurfVer(featurePoints: FeatureCollection<Point>): Feature<Point> {
+  static calculateCentroidTurfVer(featurePoints: FeatureCollection<Point>): Feature<Point> {
     return centroid(featurePoints);
   }
 
-  calculateCentroidTurfVerUsingPoints(points: number[][]): Feature<Point> {
+  static calculateCentroidTurfVerUsingPoints(points: number[][]): Feature<Point> {
     const featurePoints = turfFeatureCollection(points.map(c => turfPoint(c)));
     return centroid(featurePoints);
   }
@@ -127,15 +127,15 @@ export default class GeometryOps {
    * https://en.wikipedia.org/wiki/Centroid#Of_a_polygon
    * @param featurePoints of points forming a polygon to return the centroid for
    */
-  calculateCentroidFromFeatureCollection(featurePoints: FeatureCollection<Point>): Feature<Point> {
-    this.log.silly(`calculateCentroidFromFeatureCollection - featurePoints: FeatureCollection<Point>: ${JSON.stringify(featurePoints)}`);
+  static calculateCentroidFromFeatureCollection(featurePoints: FeatureCollection<Point>): Feature<Point> {
+    log.silly(`calculateCentroidFromFeatureCollection - featurePoints: FeatureCollection<Point>: ${JSON.stringify(featurePoints)}`);
     const points = featurePoints.features.map(f => f.geometry.coordinates);
-    return this.calculateCentroidFromPoints(points);
+    return GeometryOps.calculateCentroidFromPoints(points);
   }
 
-  calculateCentroidFromPoints(points: number[][]): Feature<Point> {
-    this.log.verbose('calculateCentroidFromPoints', `  points length: ${points.length}`);
-    return this.calculateCentroidTurfVerUsingPoints(points);
+  static calculateCentroidFromPoints(points: number[][]): Feature<Point> {
+    log.verbose('calculateCentroidFromPoints', `  points length: ${points.length}`);
+    return GeometryOps.calculateCentroidTurfVerUsingPoints(points);
 
     // I'm happy to let my code go and use the library version for now
 
@@ -160,17 +160,17 @@ export default class GeometryOps {
       area += currentArea;
       cx += (xI + xIp1) * currentArea;
       cy += (yI + yIp1) * currentArea;
-      this.log.silly('calculateCentroidFromPoints', `iteration: ${i} - area: ${area}, cx: ${cx}, cy: ${cy}`);
+      log.silly('calculateCentroidFromPoints', `iteration: ${i} - area: ${area}, cx: ${cx}, cy: ${cy}`);
     }
     area *= 1 / 2;
     cx = Math.round(cx / (6 * area));
     cy = Math.round(cy / (6 * area));
-    this.log.verbose('calculateCentroidFromPoints', `finished - area: ${area}, (centroid) cx: ${cx}, cy: ${cy}`);
+    log.verbose('calculateCentroidFromPoints', `finished - area: ${area}, (centroid) cx: ${cx}, cy: ${cy}`);
     return turfPoint([cx, cy]);
   }
 
 
-  private appendFeatureFeatureCollection(f1: FeatureCollection<Point>, f2: Feature<Point>): FeatureCollection<Point> {
+  private static appendFeatureFeatureCollection(f1: FeatureCollection<Point>, f2: Feature<Point>): FeatureCollection<Point> {
     if (f1) {
       if (f2) {
         f1.features.push(f2);
@@ -182,7 +182,7 @@ export default class GeometryOps {
   }
 
 
-  private filterSourcePoints(allPointsIntersection: FeatureCollection<Point>, allPointsMap: PointsMap): FeatureCollection<Point> {
+  private static filterSourcePoints(allPointsIntersection: FeatureCollection<Point>, allPointsMap: PointsMap): FeatureCollection<Point> {
     const filteredPoints: FeatureCollection<Point> = {
       features: [],  // Array<Feature<Point, Properties>>,
       type: 'FeatureCollection'

--- a/src/app/geometry-ops.ts
+++ b/src/app/geometry-ops.ts
@@ -70,7 +70,7 @@ export default class GeometryOps {
    *          eowData: null
    */
   async calculateLayerIntersections(eowDataGeometry: FeatureCollection<Point>, errorMarginPoints: FeatureCollection<Point>,
-                                    allPointsMap: PointsMap, waterBodyLayerPolygons: FeatureCollection<Polygon>, layerName: string ):
+                                    allPointsMap: PointsMap, waterBodyLayerPolygons: FeatureCollection<Polygon>, layerName: string):
     Promise<EowWaterBodyIntersection[]> {
     return new Promise<EowWaterBodyIntersection[]>(resolve => {
       const layerGeometry: Feature<Polygon>[] = waterBodyLayerPolygons.features;
@@ -79,7 +79,7 @@ export default class GeometryOps {
 
       this.log.info(theClass, `GeometryOps / calculateIntersection for "${layerName}"`);
       const details = layerGeometry.length > 0 ? layerGeometry[0].geometry.coordinates[0][0] : 'no polygons';
-      console.log(`layerPolygons - there are: ${layerGeometry.length} - coords of first is: ${details}`);
+      this.log.verbose(theClass, `layerPolygons - there are: ${layerGeometry.length} - coords of first is: ${details}`);
       for (const layerPolygon of layerGeometry) {
         const intersection: FeatureCollection<Point> = pointsWithinPolygon(pointsToUse, layerPolygon) as FeatureCollection<Point>;
         // TODO - now build a FeatureCollection<Point> from allPointsMapObs
@@ -185,14 +185,14 @@ export default class GeometryOps {
 
   private filterSourcePoints(allPointsIntersection: FeatureCollection<Point>, allPointsMap: PointsMap): FeatureCollection<Point> {
     const filteredPoints: FeatureCollection<Point> = {
-      features: [] ,  // Array<Feature<Point, Properties>>,
+      features: [],  // Array<Feature<Point, Properties>>,
       type: 'FeatureCollection'
     };
     const pointsAlreadyFiltered: PointsMap = {};
     allPointsIntersection.features.forEach(api => {
       const coords = api.geometry.coordinates;
       const pointString = EowDataStruct.createPointMapString(turfPoint(api.geometry.coordinates));
-      if (allPointsMap.hasOwnProperty(pointString) && ! pointsAlreadyFiltered.hasOwnProperty(pointString)) {
+      if (allPointsMap.hasOwnProperty(pointString) && !pointsAlreadyFiltered.hasOwnProperty(pointString)) {
         pointsAlreadyFiltered[pointString] = null;
         filteredPoints.features.push(allPointsMap[pointString]);
       }

--- a/src/app/gis-ops.ts
+++ b/src/app/gis-ops.ts
@@ -1,0 +1,89 @@
+import Feature from 'ol/Feature';
+import {
+  featureCollection as turfFeatureCollection,
+  FeatureCollection,
+  lineString,
+  multiLineString,
+  multiPolygon,
+  polygon,
+  Polygon
+} from '@turf/helpers';
+import {Feature as turfFeature} from '@turf/helpers/lib/geojson';
+import SimpleGeometry from 'ol/geom/SimpleGeometry';
+import lineToPolygon from '@turf/line-to-polygon';
+import {brologLevel} from './globals';
+import Brolog from 'brolog';
+
+const theClass = 'GisOps';
+const log = Brolog.instance(brologLevel);
+
+export class GisOps {
+  public static createFeatureCollection(features: Feature[]): FeatureCollection<Polygon> {
+    const theTurfFeatures: turfFeature<Polygon>[] = GisOps.createFeatures(features);
+    const featureCollection: FeatureCollection<Polygon> = turfFeatureCollection<Polygon>(theTurfFeatures);
+    return featureCollection;
+  }
+
+  public static createFeatures(features: Feature[]): turfFeature<Polygon>[] {
+    const theTurfFeatures: turfFeature<Polygon>[] = [];
+
+    features.forEach(feature => {
+      const simpleGeometry = feature.getGeometry() as SimpleGeometry;
+      switch (feature.getGeometry().getType().toLowerCase()) {
+        case  'linestring':
+          this.convertLineString(theTurfFeatures, simpleGeometry);
+          break;
+        case 'multilinestring':
+          this.convertMultiLineString(theTurfFeatures, simpleGeometry);
+          break;
+        case 'polygon':
+          this.convertPolygon(theTurfFeatures, simpleGeometry);
+          break;
+        case 'multipolygon':
+          this.convertMultiPolygon(theTurfFeatures, simpleGeometry);
+          break;
+        case 'point':
+          // ignore points
+          break;
+        default:
+          throw new Error(`Unhandled type: ${feature.getGeometry().getType()}`);
+      }
+    });
+    return theTurfFeatures;
+  }
+
+  private static convertLineString(dataDestination, simpleGeometry: SimpleGeometry) {
+    const coordinates = simpleGeometry.getCoordinates();
+    // The difference between lineString and Polygon is that a Polygon is explicitly closed (ie. the first and last coords are same) ???
+    const turfLine = lineString(coordinates);
+    if (turfLine.geometry.coordinates.length >= 3) {
+      const polygonObj = lineToPolygon(turfLine);
+      dataDestination.push(polygonObj);
+    } else {
+      log.verbose(theClass, `Turfline has < 3 coords: ${turfLine.geometry.coordinates.length} - `
+        + `${JSON.stringify(turfLine.geometry.coordinates)}`);
+    }
+  }
+
+  private static convertMultiLineString(dataDestination, simpleGeometry: SimpleGeometry) {
+    const coordinates = simpleGeometry.getCoordinates();
+    const turfLine = multiLineString(coordinates.filter(c => c.length > 2));
+    turfLine.geometry.coordinates.forEach(c => {
+      log.silly(theClass, `convertMultilineString - size of arrays: ${c.length} -> ${JSON.stringify(c)}`);
+    });
+    const polygonObj = lineToPolygon(turfLine);
+    dataDestination.push(polygonObj);
+  }
+
+  private static convertPolygon(dataDestination, simpleGeometry: SimpleGeometry) {
+    const coordinates = simpleGeometry.getCoordinates();
+    const polygonObj = polygon(coordinates);
+    dataDestination.push(polygonObj);
+  }
+
+  private static convertMultiPolygon(dataDestination, simpleGeometry: SimpleGeometry) {
+    const coordinates = simpleGeometry.getCoordinates();
+    const multiPolygon1 = multiPolygon(coordinates);
+    dataDestination.push(multiPolygon1);
+  }
+}

--- a/src/app/globals.ts
+++ b/src/app/globals.ts
@@ -1,0 +1,1 @@
+export const brologLevel = 'info';

--- a/src/app/layers-geometries.ts
+++ b/src/app/layers-geometries.ts
@@ -1,5 +1,5 @@
 import {
-  Feature as turfFeature,
+  Feature as TurfFeature,
   lineString,
   multiLineString,
   Polygon,
@@ -12,16 +12,11 @@ import lineToPolygon from '@turf/line-to-polygon';
 import GeoJSONFeature from 'ol/format/Feature';
 import OLGeoJson from 'ol/format/GeoJSON';
 import Feature from 'ol/Feature';
-
-import {
-  Brolog,
-} from 'brolog';
+import {Brolog} from 'brolog';
 import {FeatureLike} from 'ol/Feature';
 import SimpleGeometry from 'ol/geom/SimpleGeometry';
 import {EowLayers, LayersInfo} from './eow-layers';
 import GeoJSON from 'ol/format/GeoJSON';
-
-const theClass = 'LayerGeometries';
 
 /**
  * We need to determine the Waterbodies (defined through various other layers) and the contained EOW Data so we can perform actions on
@@ -29,73 +24,9 @@ const theClass = 'LayerGeometries';
  */
 
 export default class LayerGeometries {
-  layerFeatures: { [name: string]: turfFeature<Polygon>[] } = {};  // Each Layer passed to createGeometry() has multiple polygons
+  layerFeatures: { [name: string]: TurfFeature<Polygon>[] } = {};  // Each Layer passed to createGeometry() has multiple polygons
 
   constructor(private eowLayers: EowLayers, private log: Brolog) {
-  }
-
-  public createFeatureCollection(features: Feature[]): FeatureCollection<Polygon> {
-    const theTurfFeatures: turfFeature<Polygon>[] = [];
-
-    features.forEach(feature => {
-      const simpleGeometry = feature.getGeometry() as SimpleGeometry;
-      switch (feature.getGeometry().getType().toLowerCase()) {
-        case  'linestring':
-          this.convertLineString(theTurfFeatures, simpleGeometry);
-          break;
-        case 'multilinestring':
-          this.convertMultiLineString(theTurfFeatures, simpleGeometry);
-          break;
-        case 'polygon':
-          this.convertPolygon(theTurfFeatures, simpleGeometry);
-          break;
-        case 'multipolygon':
-          this.convertMultiPolygon(theTurfFeatures, simpleGeometry);
-          break;
-        case 'point':
-          // ignore points
-          break;
-        default:
-          throw new Error(`Unhandled type: ${feature.getGeometry().getType()}`);
-      }
-    });
-    const featureCollection: FeatureCollection<Polygon> = turfFeatureCollection<Polygon>(theTurfFeatures);
-    return featureCollection;
-  }
-
-  private convertLineString(dataDestination, simpleGeometry: SimpleGeometry) {
-    const coordinates = simpleGeometry.getCoordinates();
-    // The difference between lineString and Polygon is that a Polygon is explicitly closed (ie. the first and last coords are same) ???
-    const turfLine = lineString(coordinates);
-    if (turfLine.geometry.coordinates.length >= 3) {
-      const polygonObj = lineToPolygon(turfLine);
-      dataDestination.push(polygonObj);
-    } else {
-      this.log.verbose(theClass, `Turfline has < 3 coords: ${turfLine.geometry.coordinates.length} - `
-        + `${JSON.stringify(turfLine.geometry.coordinates)}`);
-    }
-  }
-
-  private convertMultiLineString(dataDestination, simpleGeometry: SimpleGeometry) {
-    const coordinates = simpleGeometry.getCoordinates();
-    const turfLine = multiLineString(coordinates.filter(c => c.length > 2));
-    turfLine.geometry.coordinates.forEach(c => {
-      this.log.silly(theClass, `convertMultilineString - size of arrays: ${c.length} -> ${JSON.stringify(c)}`);
-    });
-    const polygonObj = lineToPolygon(turfLine);
-    dataDestination.push(polygonObj);
-  }
-
-  private convertPolygon(dataDestination, simpleGeometry: SimpleGeometry) {
-    const coordinates = simpleGeometry.getCoordinates();
-    const polygonObj = polygon(coordinates);
-    dataDestination.push(polygonObj);
-  }
-
-  private convertMultiPolygon(dataDestination, simpleGeometry: SimpleGeometry) {
-    const coordinates = simpleGeometry.getCoordinates();
-    const multiPolygon1 = multiPolygon(coordinates);
-    dataDestination.push(multiPolygon1);
   }
 
   private mapNames(name: string): string {

--- a/src/app/layers.ts
+++ b/src/app/layers.ts
@@ -158,7 +158,6 @@ export class Layers {
           const bboxOrQuery = options.query ? `&cql_filter=${options.query}%20AND%20${queryBBox}` : normalBBox;
           const url = `${urlForWFS}?service=WFS&version=1.1.0&request=GetFeature&typename=${feature}&` +
             `outputFormat=application/json&srsname=${proj}${bboxOrQuery}`;
-          this.log.warn(theClass, `createLayerFromWFS - URL: ${JSON.stringify(url.split('&'))}`);
           const xhr = new XMLHttpRequest();
           xhr.open('GET', url);
           const onError = () => {

--- a/src/app/layers.ts
+++ b/src/app/layers.ts
@@ -153,8 +153,12 @@ export class Layers {
         loader: (extent, resolution, projection) => {
           const proj = projection.getCode();
           const feature = options.featurePrefix ? options.featurePrefix + ':' + options.layerOrFeatureName : options.layerOrFeatureName;
+          const normalBBox = `&bbox=${extent.join(',')},${proj}`;
+          const queryBBox = `BBOX(geom, ${extent.join(',')},'${proj}')`;
+          const bboxOrQuery = options.query ? `&cql_filter=${options.query}%20AND%20${queryBBox}` : normalBBox;
           const url = `${urlForWFS}?service=WFS&version=1.1.0&request=GetFeature&typename=${feature}&` +
-            `outputFormat=application/json&srsname=${proj}&bbox=${extent.join(',')},${proj}`;
+            `outputFormat=application/json&srsname=${proj}${bboxOrQuery}`;
+          this.log.warn(theClass, `createLayerFromWFS - URL: ${JSON.stringify(url.split('&'))}`);
           const xhr = new XMLHttpRequest();
           xhr.open('GET', url);
           const onError = () => {


### PR DESCRIPTION
I changed to using BehaviourSubjects on all the datum that drive the application and perform recalculations and redraws on the data that has changed.  I thought it would be better style and faster.  However its not.  I've kept it as I like the Observables architecture.  I had to restore checking when the map stopped moving.